### PR TITLE
Save persistent page identifier

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -31,6 +31,8 @@
 	},
 
 	"Hooks": {
+		"MultiContentSave": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onMultiContentSave",
+		"InfoAction": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onInfoAction"
 	},
 
 	"config": {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,5 +8,7 @@
 		]
 	},
 	"persistentpageidentifiers-name": "Persistent Page Identifiers",
-	"persistentpageidentifiers-description": "TODO"
+	"persistentpageidentifiers-description": "TODO",
+
+	"persistentpageidentifiers-info-label": "Persistent page identifier"
 }

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -8,5 +8,7 @@
 		]
 	},
 	"persistentpageidentifiers-name": "{{Name}}",
-	"persistentpageidentifiers-description": "{{Desc|name=PersistentPageIdentifiers|url=https://github.com/ProfessionalWiki/PersistentPageIdentifiers}}"
+	"persistentpageidentifiers-description": "{{Desc|name=PersistentPageIdentifiers|url=https://github.com/ProfessionalWiki/PersistentPageIdentifiers}}",
+
+	"persistentpageidentifiers-info-label": "Persistent page identifier label on action=info page"
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,13 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Cannot call method getPageProperty\(\) on bool\|ParserOutput\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
+
+		-
+			message: '#^Method ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks\:\:onInfoAction\(\) has parameter \$pageInfo with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/EntryPoints/PersistentPageIdentifiersHooks.php

--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -1,0 +1,52 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
+
+use CommentStoreComment;
+use IContextSource;
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Page\PageIdentity;
+use MediaWiki\Revision\RenderedRevision;
+use MediaWiki\User\UserIdentity;
+use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
+use Status;
+
+class PersistentPageIdentifiersHooks {
+
+	public static function onMultiContentSave(
+		RenderedRevision $renderedRevision,
+		UserIdentity $user,
+		CommentStoreComment $summary,
+		int $flags,
+		Status $hookStatus
+	): void {
+		PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdSaver()->savePageId(
+			$renderedRevision->getRevisionParserOutput(),
+			self::getOrGeneratePersistentPageId( $renderedRevision->getRevision()->getPage() )
+		);
+	}
+
+	private static function getOrGeneratePersistentPageId( PageIdentity $page ): string {
+		return self::getPersistentPageId( $page )
+			?? PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate();
+	}
+
+	private static function getPersistentPageId( PageIdentity $page ): ?string {
+		return MediaWikiServices::getInstance()->getPageProps()->getProperties(
+			$page,
+			PersistentPageIdentifiersExtension::PERSISTENT_PAGE_ID_PROPERTY
+		)[$page->getId()] ?? null;
+	}
+
+	public static function onInfoAction( IContextSource $context, array &$pageInfo ): void {
+		$pageInfo['header-basic'][] = [
+			$context->msg( 'persistentpageidentifiers-info-label' ),
+			$context->getWikiPage()->getParserOutput()->getPageProperty(
+				PersistentPageIdentifiersExtension::PERSISTENT_PAGE_ID_PROPERTY
+			)
+		];
+	}
+
+}

--- a/src/Persistence/PersistentPageIdSaver.php
+++ b/src/Persistence/PersistentPageIdSaver.php
@@ -1,0 +1,19 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Persistence;
+
+use ParserOutput;
+use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
+
+class PersistentPageIdSaver {
+
+	public function savePageId( ParserOutput $parser, string $id ): void {
+		$parser->setPageProperty(
+			PersistentPageIdentifiersExtension::PERSISTENT_PAGE_ID_PROPERTY,
+			$id
+		);
+	}
+
+}

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -6,8 +6,11 @@ namespace ProfessionalWiki\PersistentPageIdentifiers;
 
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\IdGenerator;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
+use ProfessionalWiki\PersistentPageIdentifiers\Persistence\PersistentPageIdSaver;
 
 class PersistentPageIdentifiersExtension {
+
+	public const PERSISTENT_PAGE_ID_PROPERTY = 'persistent_page_id';
 
 	public static function getInstance(): self {
 		/** @var ?PersistentPageIdentifiersExtension $instance */
@@ -18,6 +21,10 @@ class PersistentPageIdentifiersExtension {
 
 	public function getIdGenerator(): IdGenerator {
 		return new UuidGenerator();
+	}
+
+	public function getPersistentPageIdSaver(): PersistentPageIdSaver {
+		return new PersistentPageIdSaver();
 	}
 
 }


### PR DESCRIPTION
For:
* https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/8
* https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/9
* Show ID on page information (action=info)
* Unintentional side-effect of adding a persistent ID when editing an existing page without an ID

[Screencast_20241112_171338.webm](https://github.com/user-attachments/assets/811f4e74-f42d-44be-a090-db4a6b169f41)
