### PR TITLE
Add parser function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
         if: matrix.mw == 'master'
 
+      - name: Run parser tests
+        run: php tests/parser/parserTests.php --changetree "null" --file extensions/PersistentPageIdentifiers/tests/parser/*
+
   PHPStan:
     name: "PHPStan: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: ci test cs phpunit phpcs stan
 
-ci: test cs
+ci: test cs parser
 test: phpunit
 cs: phpcs stan
 
@@ -25,3 +25,6 @@ stan-baseline:
 
 lint-docker:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:20 npm install && npm run lint
+
+parser:
+	php ../../tests/parser/parserTests.php --changetree "null" --file tests/parser/*

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ To generate persistent identifiers for pages without them, you can run the maint
 ```bash
 php maintenance/GenerateMissingIdentifiers.php
 ```
+
+## Use or display persistent page id
+
+Use the `ppid` parser function:
+```
+{{#ppid:}}
+```

--- a/extension.json
+++ b/extension.json
@@ -32,7 +32,8 @@
 
 	"Hooks": {
 		"InfoAction": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onInfoAction",
-		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onLoadExtensionSchemaUpdates"
+		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onLoadExtensionSchemaUpdates",
+		"ParserFirstCallInit": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onParserFirstCallInit"
 	},
 
 	"config": {
@@ -48,6 +49,10 @@
 
 	"RestRoutes": [
 	],
+
+	"ExtensionMessagesFiles": {
+		"PersistentPageIdentifiersMagic": "i18n/Magic/MagicWords.php"
+	},
 
 	"manifest_version": 2
 }

--- a/i18n/Magic/MagicWords.php
+++ b/i18n/Magic/MagicWords.php
@@ -1,0 +1,8 @@
+<?php
+
+$magicWords = [];
+
+/** English (English) */
+$magicWords['en'] = [
+	'ppid' => [ 0, 'ppid' ],
+];

--- a/src/EntryPoints/PersistentPageIdFunction.php
+++ b/src/EntryPoints/PersistentPageIdFunction.php
@@ -1,0 +1,22 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
+
+use Parser;
+
+class PersistentPageIdFunction {
+
+	/**
+	 * @return array<mixed, mixed>
+	 */
+	public function handleParserFunctionCall( Parser $parser ): array {
+		return [
+			'TODO',
+			'noparse' => true,
+			'isHTML' => false,
+		];
+	}
+
+}

--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -6,6 +6,8 @@ namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
 
 use DatabaseUpdater;
 use IContextSource;
+use Parser;
+use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
 
 class PersistentPageIdentifiersHooks {
 
@@ -20,6 +22,13 @@ class PersistentPageIdentifiersHooks {
 		$updater->addExtensionTable(
 			'persistent_page_ids',
 			__DIR__ . '/../../sql/persistent_page_ids.sql'
+		);
+	}
+
+	public static function onParserFirstCallInit( Parser $parser ): void {
+		$parser->setFunctionHook(
+			'ppid',
+			PersistentPageIdentifiersExtension::getInstance()->newPersistentPageIdFunction()->handleParserFunctionCall( ... )
 		);
 	}
 

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\PersistentPageIdentifiers;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\IdGenerator;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
 use Wikimedia\Rdbms\IDatabase;
@@ -32,6 +33,10 @@ class PersistentPageIdentifiersExtension {
 
 	private function getDatabase(): IDatabase {
 		return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_PRIMARY );
+	}
+
+	public function newPersistentPageIdFunction(): PersistentPageIdFunction {
+		return new PersistentPageIdFunction();
 	}
 
 }

--- a/tests/parser/persistentPageIdentifierFunction.txt
+++ b/tests/parser/persistentPageIdentifierFunction.txt
@@ -1,0 +1,19 @@
+!! options
+parsoid-compatible
+version=2
+!! end
+
+# Force the test runner to ensure the extension is loaded
+!! functionhooks
+ppid
+!! endfunctionhooks
+
+!! test
+Persistent page identifier returns TODO
+!! config
+!! wikitext
+{{#ppid:}}
+!! html
+<p>TODO
+</p>
+!! end


### PR DESCRIPTION
Closes https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/6

* Stub parser function (name: `ppid` - feel free to change)
* Parser tests on CI