### PR TITLE
Show persistent ID on page information

### DIFF
--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -14,7 +14,9 @@ class PersistentPageIdentifiersHooks {
 	public static function onInfoAction( IContextSource $context, array &$pageInfo ): void {
 		$pageInfo['header-basic'][] = [
 			$context->msg( 'persistentpageidentifiers-info-label' ),
-			'TODO'
+			PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->getPersistentId(
+				$context->getWikiPage()->getId()
+			)
 		];
 	}
 


### PR DESCRIPTION
Closes #22

Page with persistent ID:
![Screenshot_20241113_141841](https://github.com/user-attachments/assets/d4cc7435-e2d7-4128-9c1f-86bc5c654522)

Page without:
![Screenshot_20241113_141901](https://github.com/user-attachments/assets/c3a045e0-b8d3-45d7-b686-a21ab791b2b3)
