### PR TITLE
Handle revision undeleted

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -34,7 +34,8 @@
 		"InfoAction": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onInfoAction",
 		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onLoadExtensionSchemaUpdates",
 		"ParserFirstCallInit": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onParserFirstCallInit",
-		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete"
+		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete",
+		"RevisionUndeleted": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onRevisionUndeleted"
 	},
 
 	"config": {

--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -53,4 +53,20 @@ class PersistentPageIdentifiersHooks {
 		PersistentPageIdentifiersExtension::getInstance()->newCreatePersistentPageIdentifier()->createId( $wikiPage->getId() );
 	}
 
+	public static function onRevisionUndeleted( RevisionRecord $restoredRevision, ?int $oldPageId ): void {
+		if ( $oldPageId !== null ) {
+			return;
+		}
+
+		// TODO: untested
+		$repo = PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo();
+		$oldPersistentId = $repo->getPersistentId( $restoredRevision->getPageId() );
+
+		if ( $oldPersistentId === null ) {
+			return;
+		}
+
+		$repo->savePersistentId( $restoredRevision->getPageId(), $oldPersistentId );
+	}
+
 }

--- a/tests/Integration/PageUndeleteIntegrationTest.php
+++ b/tests/Integration/PageUndeleteIntegrationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Tests\Integration;
+
+use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Tests\PersistentPageIdentifiersIntegrationTest;
+use WikiPage;
+
+/**
+ * @covers \ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdentifiersHooks::onRevisionUndeleted
+ * @group Database
+ */
+class PageUndeleteIntegrationTest extends PersistentPageIdentifiersIntegrationTest {
+
+	private PersistentPageIdentifiersRepo $repo;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->tablesUsed[] = 'persistent_page_ids';
+		$this->repo = new DatabasePersistentPageIdentifiersRepo( $this->db );
+	}
+
+	public function testUndeletedPageWithOldPageIdHasSamePersistentId(): void {
+		$page = $this->createPageWithText();
+		$pageId = $page->getId();
+		$persistentId = $this->repo->getPersistentId( $pageId );
+
+		$this->deletePage( $page );
+		$this->undeletePage( $page );
+
+		$this->assertSame( $pageId, $page->getId() );
+		$this->assertSame( $persistentId, $this->repo->getPersistentId( $pageId ) );
+	}
+
+	private function undeletePage( WikiPage $page ): void {
+		$this->getServiceContainer()->getUndeletePageFactory()
+			->newUndeletePage( $page, $this->getTestUser()->getAuthority() )
+			->undeleteUnsafe( 'test undelete' );
+	}
+
+}


### PR DESCRIPTION
For #10 

Normal page deletions already keep their page ID, and therefore persistent ID

[Screencast_20241113_215449.webm](https://github.com/user-attachments/assets/f3612bcb-ad2a-4060-b6a0-2e57faa76e58)

Marked as draft because I have not figured out how to reproduce a real scenario where the original page ID is missing after deletion.

The [docs](https://www.mediawiki.org/wiki/Manual:Archive_table#ar_page_id) mention:
> Note that because of MediaWiki supporting partial undeletion and history split/merge, there is no guarantee ar_page_id matches the page ID it's going to be undeleted to. 

My attempt at partial undeletion (picking only some revisions) still results in the same page ID.

History split/merge sounds like something that might have other complications when it comes to deciding which persistent ID to keep. However, when merging page A revisions into Page B using `Special:MergeHistory`, it just adds the revisions to Page B, and Page B keeps its persistent Id.