### PR TITLE
Add maintenance script logic

### DIFF
--- a/maintenance/GenerateMissingIdentifiers.php
+++ b/maintenance/GenerateMissingIdentifiers.php
@@ -5,6 +5,7 @@ declare( strict_types = 1 );
 namespace ProfessionalWiki\PersistentPageIdentifiers\Maintenance;
 
 use Maintenance;
+use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -20,7 +21,27 @@ class GenerateMissingIdentifiers extends Maintenance {
 	}
 
 	public function execute(): void {
-		$this->output( 'TODO' );
+		$pageIds = PersistentPageIdentifiersExtension::getInstance()->getPageIdsRepo()
+			->getPageIdsOfPagesWithoutPersistentIds();
+
+		foreach ( $pageIds as $pageId ) {
+			$this->savePersistentId( intval( $pageId ), $this->generatePersistentId() );
+		}
+
+		$pageIdsCount = count( $pageIds );
+
+		$this->output( "Created $pageIdsCount persistent IDs\n" );
+	}
+
+	private function generatePersistentId(): string {
+		return PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate();
+	}
+
+	private function savePersistentId( int $pageId, string $persistentId ): void {
+		PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->savePersistentId(
+			$pageId,
+			$persistentId
+		);
 	}
 
 }

--- a/maintenance/GenerateMissingIdentifiers.php
+++ b/maintenance/GenerateMissingIdentifiers.php
@@ -25,17 +25,17 @@ class GenerateMissingIdentifiers extends Maintenance {
 
 		while ( true ) {
 			$pageIds = $this->getNextBatchOfPageIdsForPagesWithoutPersistentIds();
-			$batchCount = count( $pageIds );
+			$batchSize = count( $pageIds );
 
-			if ( $batchCount === 0 ) {
+			if ( $batchSize === 0 ) {
 				break;
 			}
 
-			$this->output( "Generating persistent ids for batch of $batchCount pages\n" );
+			$this->output( "Generating persistent ids for batch of $batchSize pages\n" );
 
-			$this->savePersistentIds( $pageIds, $this->generatePersistentIds( $batchCount ) );
+			$this->savePersistentIds( $pageIds, $this->generateBulkPersistentIds( $batchSize ) );
 
-			$generatedIdsCount += $batchCount;
+			$generatedIdsCount += $batchSize;
 		}
 
 		$this->output( "Generated $generatedIdsCount persistent IDs\n" );
@@ -46,14 +46,14 @@ class GenerateMissingIdentifiers extends Maintenance {
 	 */
 	private function getNextBatchOfPageIdsForPagesWithoutPersistentIds(): array {
 		return PersistentPageIdentifiersExtension::getInstance()->getPageIdsRepo()
-			->getPageIdsOfPagesWithoutPersistentIds( limit: 100 );
+			->getPageIdsOfPagesWithoutPersistentIds( limit: 1000 );
 	}
 
 	/**
 	 * @param int $count
 	 * @return string[]
 	 */
-	private function generatePersistentIds( int $count ): array {
+	private function generateBulkPersistentIds( int $count ): array {
 		return array_map(
 			fn() => PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate(),
 			range( 1, $count )

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,12 +7,6 @@ parameters:
 			path: src/Adapters/DatabasePersistentPageIdentifiersRepo.php
 
 		-
-			message: '#^Parameter \#2 \$rows of method Wikimedia\\Rdbms\\IDatabase\:\:insert\(\) expects array\<array\>, array\<string, int\|string\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/Adapters/DatabasePersistentPageIdentifiersRepo.php
-
-		-
 			message: '#^Cannot call method getArticleID\(\) on Title\|null\.$#'
 			identifier: method.nonObject
 			count: 1

--- a/src/Adapters/DatabasePersistentPageIdentifiersRepo.php
+++ b/src/Adapters/DatabasePersistentPageIdentifiersRepo.php
@@ -14,13 +14,13 @@ class DatabasePersistentPageIdentifiersRepo implements PersistentPageIdentifiers
 	) {
 	}
 
-	public function savePersistentId( int $pageId, string $persistentId ): void {
+	public function savePersistentIds( array $ids ): void {
 		$this->database->insert(
 			'persistent_page_ids',
-			[
-				'page_id' => $pageId,
-				'persistent_id' => $persistentId
-			]
+			array_map(
+				fn( $pageId ) => [ 'page_id' => $pageId, 'persistent_id' => $ids[$pageId] ],
+				array_keys( $ids )
+			)
 		);
 	}
 

--- a/src/Adapters/PageIdsRepo.php
+++ b/src/Adapters/PageIdsRepo.php
@@ -13,13 +13,21 @@ class PageIdsRepo {
 	) {
 	}
 
-	public function getPageIdsOfPagesWithoutPersistentIds(): array {
-		return $this->database->newSelectQueryBuilder()
-			->select( 'p.page_id' )
-			->from( 'page', 'p' )
-			->leftJoin( 'persistent_page_ids', 'ppi', 'p.page_id = ppi.page_id' )
-			->where( 'ppi.page_id IS NULL' )
-			->fetchFieldValues();
+	/**
+	 * @return int[]
+	 */
+	public function getPageIdsOfPagesWithoutPersistentIds( int $limit ): array {
+		return array_map(
+			fn( $field ) => (int)$field,
+			$this->database->newSelectQueryBuilder()
+				->select( 'p.page_id' )
+				->from( 'page', 'p' )
+				->leftJoin( 'persistent_page_ids', 'ppi', 'p.page_id = ppi.page_id' )
+				->where( 'ppi.page_id IS NULL' )
+				->orderBy( 'p.page_id' )
+				->limit( $limit )
+				->fetchFieldValues()
+		);
 	}
 
 }

--- a/src/Adapters/PageIdsRepo.php
+++ b/src/Adapters/PageIdsRepo.php
@@ -1,0 +1,25 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Adapters;
+
+use Wikimedia\Rdbms\IDatabase;
+
+class PageIdsRepo {
+
+	public function __construct(
+		private readonly IDatabase $database
+	) {
+	}
+
+	public function getPageIdsOfPagesWithoutPersistentIds(): array {
+		return $this->database->newSelectQueryBuilder()
+			->select( 'p.page_id' )
+			->from( 'page', 'p' )
+			->leftJoin( 'persistent_page_ids', 'ppi', 'p.page_id = ppi.page_id' )
+			->where( 'ppi.page_id IS NULL' )
+			->fetchFieldValues();
+	}
+
+}

--- a/src/Application/PersistentPageIdentifiersRepo.php
+++ b/src/Application/PersistentPageIdentifiersRepo.php
@@ -6,7 +6,10 @@ namespace ProfessionalWiki\PersistentPageIdentifiers\Application;
 
 interface PersistentPageIdentifiersRepo {
 
-	public function savePersistentId( int $pageId, string $persistentId ): void;
+	/**
+	 * @param array<int, string> $ids
+	 */
+	public function savePersistentIds( array $ids ): void;
 
 	public function getPersistentId( int $pageId ): ?string;
 

--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -56,9 +56,8 @@ class PersistentPageIdentifiersHooks {
 			return;
 		}
 
-		PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->savePersistentId(
-			$wikiPage->getId(),
-			PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate()
+		PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->savePersistentIds(
+			[ $wikiPage->getId() => PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate() ]
 		);
 	}
 

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\PersistentPageIdentifiers;
 
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\IdGenerator;
@@ -46,6 +47,12 @@ class PersistentPageIdentifiersExtension {
 	public function newPersistentPageIdFormatter(): PersistentPageIdFormatter {
 		return new PersistentPageIdFormatter(
 			MediaWikiServices::getInstance()->getMainConfig()->get( 'PersistentPageIdentifiersFormat' )
+		);
+	}
+
+	public function getPageIdsRepo(): PageIdsRepo {
+		return new PageIdsRepo(
+			$this->getDatabase()
 		);
 	}
 

--- a/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php
+++ b/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php
@@ -7,7 +7,7 @@ namespace ProfessionalWiki\PersistentPageIdentifiers\Tests\Adapters;
 use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
-use Wikimedia\Rdbms\DBQueryError;
+use Wikimedia\Rdbms\DBError;
 
 /**
  * @covers \ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo
@@ -17,6 +17,7 @@ class DatabasePersistentPageIdentifiersRepoTest extends MediaWikiIntegrationTest
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->tablesUsed[] = 'page';
 		$this->tablesUsed[] = 'persistent_page_ids';
 	}
 
@@ -35,29 +36,29 @@ class DatabasePersistentPageIdentifiersRepoTest extends MediaWikiIntegrationTest
 		$pageId = 42;
 		$persistentId = '00000000-0000-0000-0000-000000000042';
 
-		$repo->savePersistentId( $pageId, $persistentId );
+		$repo->savePersistentIds( [ $pageId => $persistentId ] );
 
 		$this->assertSame( $persistentId, $repo->getPersistentId( $pageId ) );
 	}
 
 	public function testSetPersistentIdThrowsExceptionOnDuplicatePageId(): void {
 		$repo = $this->newRepo();
-		$pageId = 1;
+		$pageId = 100;
 
-		$repo->savePersistentId( $pageId, '00000000-0000-0000-0000-000000000010' );
+		$repo->savePersistentIds( [ $pageId => '00000000-0000-0000-0000-000000000010' ] );
 
-		$this->expectException( DBQueryError::class );
-		$repo->savePersistentId( $pageId, '00000000-0000-0000-0000-000000000020' );
+		$this->expectException( DBError::class );
+		$repo->savePersistentIds( [ $pageId => '00000000-0000-0000-0000-000000000020' ] );
 	}
 
 	public function testSetPersistentIdThrowsExceptionOnDuplicatePersistentId(): void {
 		$repo = $this->newRepo();
 		$persistentId = '00000000-0000-0000-0000-000000000001';
 
-		$repo->savePersistentId( 1, $persistentId );
+		$repo->savePersistentIds( [ 100 => $persistentId ] );
 
-		$this->expectException( DBQueryError::class );
-		$repo->savePersistentId( 2, $persistentId );
+		$this->expectException( DBError::class );
+		$repo->savePersistentIds( [ 200 => $persistentId ] );
 	}
 
 }

--- a/tests/Adapters/PageIdsRepoTest.php
+++ b/tests/Adapters/PageIdsRepoTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Tests\Adapters;
+
+use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Tests\PersistentPageIdentifiersIntegrationTest;
+
+/**
+ * @covers \ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo
+ * @group Database
+ */
+class PageIdsRepoTest extends PersistentPageIdentifiersIntegrationTest {
+
+	private PageIdsRepo $repo;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->tablesUsed[] = 'page';
+		$this->tablesUsed[] = 'persistent_page_ids';
+		$this->repo = new PageIdsRepo( $this->db );
+	}
+
+	public function testReturnsAnEmptyArrayWhenThereAreNoPages(): void {
+		$this->assertSame( [], $this->repo->getPageIdsOfPagesWithoutPersistentIds() );
+	}
+
+	public function testReturnsAnEmptyArrayWhenThereAreNoPagesWithPersistentIds(): void {
+		$this->createPageWithText();
+		$this->createPageWithText();
+
+		$this->assertSame( [], $this->repo->getPageIdsOfPagesWithoutPersistentIds() );
+	}
+
+	public function testReturnsPageIdsForPagesWithoutPersistentIds(): void {
+		$this->disablePageSaveHook();
+		$page1 = $this->createPageWithText();
+		$page2 = $this->createPageWithText();
+
+		$this->assertSame(
+			[ (string)$page1->getId(), (string)$page2->getId() ],
+			$this->repo->getPageIdsOfPagesWithoutPersistentIds()
+		);
+	}
+
+	public function testReturnsPageIdsOnlyForPagesWithoutPersistentIds(): void {
+		$this->disablePageSaveHook();
+		$page1 = $this->createPageWithText();
+		$page2 = $this->createPageWithText();
+
+		$this->enablePageSaveHook();
+		$this->createPageWithText();
+		$this->createPageWithText();
+
+		$this->assertSame(
+			[ (string)$page1->getId(), (string)$page2->getId() ],
+			$this->repo->getPageIdsOfPagesWithoutPersistentIds()
+		);
+	}
+
+}

--- a/tests/Adapters/PageIdsRepoTest.php
+++ b/tests/Adapters/PageIdsRepoTest.php
@@ -23,14 +23,14 @@ class PageIdsRepoTest extends PersistentPageIdentifiersIntegrationTest {
 	}
 
 	public function testReturnsAnEmptyArrayWhenThereAreNoPages(): void {
-		$this->assertSame( [], $this->repo->getPageIdsOfPagesWithoutPersistentIds() );
+		$this->assertSame( [], $this->repo->getPageIdsOfPagesWithoutPersistentIds( limit: 100 ) );
 	}
 
 	public function testReturnsAnEmptyArrayWhenThereAreNoPagesWithPersistentIds(): void {
 		$this->createPageWithText();
 		$this->createPageWithText();
 
-		$this->assertSame( [], $this->repo->getPageIdsOfPagesWithoutPersistentIds() );
+		$this->assertSame( [], $this->repo->getPageIdsOfPagesWithoutPersistentIds( limit: 100 ) );
 	}
 
 	public function testReturnsPageIdsForPagesWithoutPersistentIds(): void {
@@ -39,8 +39,8 @@ class PageIdsRepoTest extends PersistentPageIdentifiersIntegrationTest {
 		$page2 = $this->createPageWithText();
 
 		$this->assertSame(
-			[ (string)$page1->getId(), (string)$page2->getId() ],
-			$this->repo->getPageIdsOfPagesWithoutPersistentIds()
+			[ $page1->getId(), $page2->getId() ],
+			$this->repo->getPageIdsOfPagesWithoutPersistentIds( limit: 100 )
 		);
 	}
 
@@ -54,8 +54,20 @@ class PageIdsRepoTest extends PersistentPageIdentifiersIntegrationTest {
 		$this->createPageWithText();
 
 		$this->assertSame(
-			[ (string)$page1->getId(), (string)$page2->getId() ],
-			$this->repo->getPageIdsOfPagesWithoutPersistentIds()
+			[ $page1->getId(), $page2->getId() ],
+			$this->repo->getPageIdsOfPagesWithoutPersistentIds( limit: 100 )
+		);
+	}
+
+	public function testReturnsPageIdsForPagesWithoutPersistentIdsUpToLimit(): void {
+		$this->disablePageSaveHook();
+		$page1 = $this->createPageWithText();
+		$this->createPageWithText();
+		$this->createPageWithText();
+
+		$this->assertSame(
+			[ $page1->getId() ],
+			$this->repo->getPageIdsOfPagesWithoutPersistentIds( limit: 1 )
 		);
 	}
 

--- a/tests/Integration/PageSaveIntegrationTest.php
+++ b/tests/Integration/PageSaveIntegrationTest.php
@@ -19,6 +19,7 @@ class PageSaveIntegrationTest extends PersistentPageIdentifiersIntegrationTest {
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->tablesUsed[] = 'page';
 		$this->tablesUsed[] = 'persistent_page_ids';
 		$this->repo = new DatabasePersistentPageIdentifiersRepo( $this->db );
 	}

--- a/tests/Integration/PageSaveIntegrationTest.php
+++ b/tests/Integration/PageSaveIntegrationTest.php
@@ -39,12 +39,12 @@ class PageSaveIntegrationTest extends PersistentPageIdentifiersIntegrationTest {
 	}
 
 	public function testExistingPageDoesNotGetPersistentId(): void {
-		$this->clearHook( 'PageSaveComplete' );
+		$this->disablePageSaveHook();
 		$page = $this->createPageWithText();
 
 		$this->assertNull( $this->repo->getPersistentId( $page->getId() ) );
 
-		$this->setTemporaryHook( 'PageSaveComplete', [ PersistentPageIdentifiersHooks::class, 'onPageSaveComplete' ] );
+		$this->enablePageSaveHook();
 		$this->editPage( $page, 'Updated' );
 
 		$this->assertNull( $this->repo->getPersistentId( $page->getId() ) );

--- a/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
+++ b/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
@@ -48,7 +48,7 @@ HTML
 	}
 
 	public function testParserFunctionReturnsNothingForPageWithoutPersistentId(): void {
-		$this->clearHook( 'PageSaveComplete' );
+		$this->disablePageSaveHook();
 
 		$page = $this->createPageWithText();
 		$this->editPage( $page, '{{#ppid:}}' );

--- a/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
+++ b/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
@@ -20,6 +20,7 @@ class PersistentPageIdFunctionIntegrationTest extends PersistentPageIdentifiersI
 
 	protected function setUp(): void {
 		parent::setUp();
+		$this->tablesUsed[] = 'page';
 		$this->tablesUsed[] = 'persistent_page_ids';
 		$this->repo = new DatabasePersistentPageIdentifiersRepo( $this->db );
 		$this->overrideConfigValue( 'PersistentPageIdentifiersFormat', '$1' );

--- a/tests/Maintenance/GenerateMissingIdentifiersTest.php
+++ b/tests/Maintenance/GenerateMissingIdentifiersTest.php
@@ -21,7 +21,7 @@ class GenerateMissingIdentifiersTest extends MaintenanceBaseTestCase {
 	public function testRuns() {
 		$this->maintenance->execute();
 
-		$this->expectOutputRegex( '/Created/' );
+		$this->expectOutputRegex( '/Generated/' );
 	}
 
 }

--- a/tests/Maintenance/GenerateMissingIdentifiersTest.php
+++ b/tests/Maintenance/GenerateMissingIdentifiersTest.php
@@ -9,6 +9,7 @@ use ProfessionalWiki\PersistentPageIdentifiers\Maintenance\GenerateMissingIdenti
 
 /**
  * @covers \ProfessionalWiki\PersistentPageIdentifiers\Maintenance\GenerateMissingIdentifiers
+ * @group Database
  */
 class GenerateMissingIdentifiersTest extends MaintenanceBaseTestCase {
 
@@ -20,7 +21,7 @@ class GenerateMissingIdentifiersTest extends MaintenanceBaseTestCase {
 	public function testRuns() {
 		$this->maintenance->execute();
 
-		$this->expectOutputRegex( '/TODO/' );
+		$this->expectOutputRegex( '/Created/' );
 	}
 
 }

--- a/tests/PersistentPageIdentifiersIntegrationTest.php
+++ b/tests/PersistentPageIdentifiersIntegrationTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PersistentPageIdentifiers\Tests;
 
+use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdentifiersHooks;
 use Title;
 use WikiPage;
 
@@ -20,6 +21,14 @@ class PersistentPageIdentifiersIntegrationTest extends \MediaWikiIntegrationTest
 	private function createUniqueTitle(): Title {
 		static $pageCounter = 0;
 		return Title::newFromText( 'PPITestPage' . ++$pageCounter );
+	}
+
+	protected function disablePageSaveHook(): void {
+		$this->clearHook( 'PageSaveComplete' );
+	}
+
+	protected function enablePageSaveHook(): void {
+		$this->setTemporaryHook( 'PageSaveComplete', [ PersistentPageIdentifiersHooks::class, 'onPageSaveComplete' ] );
 	}
 
 }


### PR DESCRIPTION
For #7 #25 

This can be cleaned up and made more testable, but this seems to be the minimal core logic to generate persistent IDs for pages without them.

The biggest improvement, if necessary, would be some kind of batching/limit or timeout in case there are huge amounts of pages.

Manual testing with pages created before enabling the extension:
![Screenshot_20241113_231229](https://github.com/user-attachments/assets/2b2399af-12f1-41e5-ac2f-2fe7abdffdae)
