### PR TITLE
Add persistent id to API info

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -34,7 +34,8 @@
 		"InfoAction": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onInfoAction",
 		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onLoadExtensionSchemaUpdates",
 		"ParserFirstCallInit": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onParserFirstCallInit",
-		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete"
+		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete",
+		"APIQueryAfterExecute": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onAPIQueryAfterExecute"
 	},
 
 	"config": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,9 +13,27 @@ parameters:
 			path: src/EntryPoints/PersistentPageIdFunction.php
 
 		-
+			message: '#^Argument of an invalid type mixed supplied for foreach, only iterables are supported\.$#'
+			identifier: foreach.nonIterable
+			count: 1
+			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
+
+		-
+			message: '#^Cannot access offset ''pageid'' on mixed\.$#'
+			identifier: offsetAccess.nonOffsetAccessible
+			count: 1
+			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
+
+		-
 			message: '#^Method ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks\:\:onInfoAction\(\) has parameter \$pageInfo with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
+			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
+
+		-
+			message: '#^Parameter \#1 \$value of function intval expects array\|bool\|float\|int\|resource\|string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 2
 			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
 
 		-


### PR DESCRIPTION
Closes #34 

* Uses a hook to add values to the core Actions Info API.
* Works with other result formats
* Can be used to retrieve multiple pages
* Adds nothing when an invalid page is specified
* Adds id or `null` for valid pages

API request:
`/api.php?action=query&prop=info&titles=Main Page|Page|Does Not Exist|Foo`

![image](https://github.com/user-attachments/assets/809e8603-0c00-4169-83f0-c4a5b33dcc72)

----

Future low priority improvement:
* fetch persistent ids in bulk