### PR TITLE
make test compatible for all php and phpunit versions

### DIFF
--- a/tests/Infrastructure/UuidGeneratorTest.php
+++ b/tests/Infrastructure/UuidGeneratorTest.php
@@ -4,6 +4,7 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PersistentPageIdentifiers\Tests\Infrastructure;
 
+use PHPUnit\Framework\Constraint\RegularExpression;
 use PHPUnit\Framework\TestCase;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
 
@@ -13,9 +14,9 @@ use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
 class UuidGeneratorTest extends TestCase {
 
 	public function testGeneratesValidUuid7(): void {
-		$this->assertRegExp(
-			'/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
-			( new UuidGenerator() )->generate()
+		$this->assertThat(
+			( new UuidGenerator() )->generate(),
+			new RegularExpression( '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/' )
 		);
 	}
 


### PR DESCRIPTION
That deprecation warning was like a tiny pebble in my developer shoes. I am not sure if we need this or not. Feel free to close this if it is not good.

Before:

![image](https://github.com/user-attachments/assets/3141aece-9298-4c5f-a6c9-63f36d8b4ea5)


After:
![image](https://github.com/user-attachments/assets/8854e209-3e02-4bf5-87dc-d5613d084837)

