### PR TITLE
Add persistent ID formatter

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -38,6 +38,10 @@
 	},
 
 	"config": {
+		"PersistentPageIdentifiersFormat": {
+			"description": "The format to use when displaying persistent page identifiers. '$1' will be replaced with the actual identifier.",
+			"value": "$1"
+		}
 	},
 
 	"ResourceFileModulePaths": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -29,3 +29,9 @@ parameters:
 			identifier: return.type
 			count: 1
 			path: src/PersistentPageIdentifiersExtension.php
+
+		-
+			message: '#^Parameter \#1 \$format of class ProfessionalWiki\\PersistentPageIdentifiers\\Presentation\\PersistentPageIdFormatter constructor expects string, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PersistentPageIdentifiersExtension.php

--- a/src/EntryPoints/PersistentPageIdFunction.php
+++ b/src/EntryPoints/PersistentPageIdFunction.php
@@ -7,12 +7,14 @@ namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
 use MediaWiki\Page\PageReference;
 use Parser;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter;
 use Title;
 
 class PersistentPageIdFunction {
 
 	public function __construct(
-		private readonly PersistentPageIdentifiersRepo $repo
+		private readonly PersistentPageIdentifiersRepo $repo,
+		private readonly PersistentPageIdFormatter $idFormatter,
 	) {
 	}
 
@@ -27,14 +29,14 @@ class PersistentPageIdFunction {
 		}
 
 		return [
-			$this->repo->getPersistentId( $this->getPageId( $page ) ) ?? '',
+			$this->idFormatter->format( $this->getPersistentIdForPage( $page ) ),
 			'noparse' => true,
 			'isHTML' => false,
 		];
 	}
 
-	private function getPageId( PageReference $page ): int {
-		return Title::castFromPageReference( $page )->getArticleID();
+	private function getPersistentIdForPage( PageReference $page ): ?string {
+		return $this->repo->getPersistentId( Title::castFromPageReference( $page )->getArticleID() );
 	}
 
 }

--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -18,10 +18,16 @@ class PersistentPageIdentifiersHooks {
 	public static function onInfoAction( IContextSource $context, array &$pageInfo ): void {
 		$pageInfo['header-basic'][] = [
 			$context->msg( 'persistentpageidentifiers-info-label' ),
-			PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->getPersistentId(
-				$context->getWikiPage()->getId()
+			PersistentPageIdentifiersExtension::getInstance()->newPersistentPageIdFormatter()->format(
+				self::getPersistentIdForPage( $context->getWikiPage() )
 			)
 		];
+	}
+
+	private static function getPersistentIdForPage( WikiPage $page ): ?string {
+		return PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->getPersistentId(
+			$page->getId()
+		);
 	}
 
 	public static function onLoadExtensionSchemaUpdates( DatabaseUpdater $updater ): void {

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -11,6 +11,7 @@ use ProfessionalWiki\PersistentPageIdentifiers\Application\UseCases\CreatePersis
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\IdGenerator;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
+use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter;
 use Wikimedia\Rdbms\IDatabase;
 
 class PersistentPageIdentifiersExtension {
@@ -38,7 +39,14 @@ class PersistentPageIdentifiersExtension {
 
 	public function newPersistentPageIdFunction(): PersistentPageIdFunction {
 		return new PersistentPageIdFunction(
-			$this->getPersistentPageIdentifiersRepo()
+			$this->getPersistentPageIdentifiersRepo(),
+			$this->newPersistentPageIdFormatter()
+		);
+	}
+
+	public function newPersistentPageIdFormatter(): PersistentPageIdFormatter {
+		return new PersistentPageIdFormatter(
+			MediaWikiServices::getInstance()->getMainConfig()->get( 'PersistentPageIdentifiersFormat' )
 		);
 	}
 

--- a/src/Presentation/PersistentPageIdFormatter.php
+++ b/src/Presentation/PersistentPageIdFormatter.php
@@ -1,0 +1,24 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Presentation;
+
+class PersistentPageIdFormatter {
+
+	public function __construct(
+		private readonly string $format
+	) {
+	}
+
+	public function format( ?string $persistentId ): string {
+		if ( $persistentId === null ) {
+			return '';
+		}
+
+		return htmlspecialchars(
+			str_replace( '$1', $persistentId, $this->format )
+		);
+	}
+
+}

--- a/tests/Presentation/PersistentPageIdFormatterTest.php
+++ b/tests/Presentation/PersistentPageIdFormatterTest.php
@@ -13,7 +13,7 @@ use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdForm
 class PersistentPageIdFormatterTest extends TestCase {
 
 	public function testReturnsEmptyStringForNullId(): void {
-		$formatter = new PersistentPageIdFormatter( '$1' );
+		$formatter = new PersistentPageIdFormatter( 'foo $1 bar' );
 		$this->assertSame( '', $formatter->format( null ) );
 	}
 

--- a/tests/Presentation/PersistentPageIdFormatterTest.php
+++ b/tests/Presentation/PersistentPageIdFormatterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Tests\Presentation;
+
+use PHPUnit\Framework\TestCase;
+use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter;
+
+/**
+ * @covers \ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter
+ */
+class PersistentPageIdFormatterTest extends TestCase {
+
+	public function testReturnsEmptyStringForNullId(): void {
+		$formatter = new PersistentPageIdFormatter( '$1' );
+		$this->assertSame( '', $formatter->format( null ) );
+	}
+
+	public function testReturnsFormattedId(): void {
+		$formatter = new PersistentPageIdFormatter( 'foo $1 bar' );
+		$this->assertSame( 'foo 42 bar', $formatter->format( '42' ) );
+	}
+
+	public function testEscapesHtmlInFormat(): void {
+		$formatter = new PersistentPageIdFormatter( '<strong>$1</strong>' );
+		$this->assertSame( '&lt;strong&gt;42&lt;/strong&gt;', $formatter->format( '42' ) );
+	}
+
+	public function testEscapesHtmlInId(): void {
+		$formatter = new PersistentPageIdFormatter( '$1' );
+		$this->assertSame( '&lt;strong&gt;42&lt;/strong&gt;', $formatter->format( '<strong>42</strong>' ) );
+	}
+
+}


### PR DESCRIPTION
Closes #26 

* `$wgPersistentPageIdentifiersFormat` config
* Formatter service
* Output formatted ID in parser function
* Output formatted ID in page info tab

This does not handle invalid config:
* non-strings
* strings without `$1`
* multiple occurences of `$1` (it will simply replace all of them)

Parser function:
![Screenshot_20241114_183759](https://github.com/user-attachments/assets/f6fba1d5-b582-42c0-921b-3e7e92638f2c)

Page info:
![Screenshot_20241114_183824](https://github.com/user-attachments/assets/14b41c0f-3312-4c14-925b-e62202f6426f)

TODO:
* ID formatting in API: https://github.com/ProfessionalWiki/PersistentPageIdentifiers/pull/36
