### PR TITLE
WIP: Show ID immediately

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -34,7 +34,7 @@
 		"InfoAction": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onInfoAction",
 		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onLoadExtensionSchemaUpdates",
 		"ParserFirstCallInit": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onParserFirstCallInit",
-		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete"
+		"RevisionFromEditComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onRevisionFromEditComplete"
 	},
 
 	"config": {

--- a/src/EntryPoints/PersistentPageIdFunction.php
+++ b/src/EntryPoints/PersistentPageIdFunction.php
@@ -31,6 +31,7 @@ class PersistentPageIdFunction {
 		}
 
 		$title = Title::castFromPageReference( $page );
+
 		$id = $this->getPersistentIdForPage( $page );
 
 		if ( $id === null && $title->exists() ) {

--- a/src/EntryPoints/PersistentPageIdFunction.php
+++ b/src/EntryPoints/PersistentPageIdFunction.php
@@ -4,17 +4,19 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\PageReference;
 use Parser;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
 use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter;
 use Title;
+use WikiPage;
 
 class PersistentPageIdFunction {
 
 	public function __construct(
-		private readonly PersistentPageIdentifiersRepo $repo,
-		private readonly PersistentPageIdFormatter $idFormatter,
+		private readonly PersistentPageIdentifiersRepo $repo, private readonly PersistentPageIdFormatter $idFormatter,
 	) {
 	}
 
@@ -28,8 +30,17 @@ class PersistentPageIdFunction {
 			return [];
 		}
 
+		$title = Title::castFromPageReference( $page );
+		$id = $this->getPersistentIdForPage( $page );
+
+		if ( $id === null && $title->exists() ) {
+			$pageId = $title->getArticleID();
+			$id = PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate();
+			$this->repo->savePersistentIds( [ $pageId => $id ] );
+		}
+
 		return [
-			htmlspecialchars( $this->idFormatter->format( $this->getPersistentIdForPage( $page ) ) ),
+			htmlspecialchars( $this->idFormatter->format( $id ) ),
 			'noparse' => true,
 			'isHTML' => false,
 		];

--- a/src/EntryPoints/PersistentPageIdFunction.php
+++ b/src/EntryPoints/PersistentPageIdFunction.php
@@ -8,7 +8,6 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\PageReference;
 use Parser;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
-use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
 use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter;
 use Title;
 use WikiPage;
@@ -30,18 +29,8 @@ class PersistentPageIdFunction {
 			return [];
 		}
 
-		$title = Title::castFromPageReference( $page );
-
-		$id = $this->getPersistentIdForPage( $page );
-
-		if ( $id === null && $title->exists() ) {
-			$pageId = $title->getArticleID();
-			$id = PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate();
-			$this->repo->savePersistentIds( [ $pageId => $id ] );
-		}
-
 		return [
-			htmlspecialchars( $this->idFormatter->format( $id ) ),
+			htmlspecialchars( $this->idFormatter->format( $this->getPersistentIdForPage( $page ) ) ),
 			'noparse' => true,
 			'isHTML' => false,
 		];

--- a/tests/Integration/InfoActionIntegrationTest.php
+++ b/tests/Integration/InfoActionIntegrationTest.php
@@ -28,7 +28,7 @@ class InfoActionIntegrationTest extends PersistentPageIdentifiersIntegrationTest
 	}
 
 	public function testShowsEmptyStringForPageWithoutPersistentId(): void {
-		$this->clearHook( 'PageSaveComplete' );
+		$this->clearHook( 'RevisionFromEditComplete' );
 
 		$page = $this->createPageWithText();
 

--- a/tests/Integration/PageSaveIntegrationTest.php
+++ b/tests/Integration/PageSaveIntegrationTest.php
@@ -10,7 +10,7 @@ use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdentif
 use ProfessionalWiki\PersistentPageIdentifiers\Tests\PersistentPageIdentifiersIntegrationTest;
 
 /**
- * @covers \ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdentifiersHooks::onPageSaveComplete
+ * @covers \ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdentifiersHooks::onRevisionFromEditComplete
  * @group Database
  */
 class PageSaveIntegrationTest extends PersistentPageIdentifiersIntegrationTest {

--- a/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
+++ b/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
@@ -50,6 +50,7 @@ HTML
 
 	public function testParserFunctionReturnsNothingForPageWithoutPersistentId(): void {
 		$this->disablePageSaveHook();
+		$this->disableParserFunction();
 
 		$page = $this->createPageWithText();
 		$this->editPage( $page, '{{#ppid:}}' );

--- a/tests/PersistentPageIdentifiersIntegrationTest.php
+++ b/tests/PersistentPageIdentifiersIntegrationTest.php
@@ -24,15 +24,8 @@ class PersistentPageIdentifiersIntegrationTest extends \MediaWikiIntegrationTest
 	}
 
 	protected function disablePageSaveHook(): void {
-		$this->clearHook( 'PageSaveComplete' );
+		$this->clearHook( 'RevisionFromEditComplete' );
 
-	}
-
-	protected function disableParserFunction(): void {
-		$parser = $this->getServiceContainer()->getParser();
-		$parser->setFunctionHook( 'ppid', static function () {
-			return [ '', 'noparse' => true ];
-		} );
 	}
 
 	protected function enablePageSaveHook(): void {

--- a/tests/PersistentPageIdentifiersIntegrationTest.php
+++ b/tests/PersistentPageIdentifiersIntegrationTest.php
@@ -25,6 +25,14 @@ class PersistentPageIdentifiersIntegrationTest extends \MediaWikiIntegrationTest
 
 	protected function disablePageSaveHook(): void {
 		$this->clearHook( 'PageSaveComplete' );
+
+	}
+
+	protected function disableParserFunction(): void {
+		$parser = $this->getServiceContainer()->getParser();
+		$parser->setFunctionHook( 'ppid', static function () {
+			return [ '', 'noparse' => true ];
+		} );
 	}
 
 	protected function enablePageSaveHook(): void {


### PR DESCRIPTION
For: https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/30

This works but `wikipage->purge` isn't working. HOwever this is problematic since it creates ID for pages that don't even have parser function. I am not sure if I am purging at the right place.

![page](https://github.com/user-attachments/assets/337c4fcf-3ea0-43f3-83a5-718c03e979f0)
