### PR TITLE
Add persistent ids REST API

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -53,6 +53,11 @@
 	},
 
 	"RestRoutes": [
+		{
+			"path": "/persistent-page-identifiers/v1/pages",
+			"method": [ "GET" ],
+			"factory": "ProfessionalWiki\\PersistentPageIdentifiers\\PersistentPageIdentifiersExtension::newGetPersistentPageIdentifiersApi"
+		}
 	],
 
 	"ExtensionMessagesFiles": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,8 +1,14 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Method ProfessionalWiki\\PersistentPageIdentifiers\\Adapters\\DatabasePersistentPageIdentifiersRepo\:\:getPersistentId\(\) should return string\|null but returns mixed\.$#'
-			identifier: return.type
+			message: '#^Cannot access property \$page_id on array\|bool\|stdClass\.$#'
+			identifier: property.nonObject
+			count: 1
+			path: src/Adapters/DatabasePersistentPageIdentifiersRepo.php
+
+		-
+			message: '#^Cannot access property \$persistent_id on array\|bool\|stdClass\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/Adapters/DatabasePersistentPageIdentifiersRepo.php
 

--- a/src/Application/PersistentPageIdentifiersRepo.php
+++ b/src/Application/PersistentPageIdentifiersRepo.php
@@ -13,4 +13,10 @@ interface PersistentPageIdentifiersRepo {
 
 	public function getPersistentId( int $pageId ): ?string;
 
+	/**
+	 * @param int[] $pageIds
+	 * @return array<string|null>
+	 */
+	public function getPersistentIds( array $pageIds ): array;
+
 }

--- a/src/EntryPoints/GetPersistentPageIdentifiersApi.php
+++ b/src/EntryPoints/GetPersistentPageIdentifiersApi.php
@@ -1,0 +1,56 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
+
+use MediaWiki\Rest\Response;
+use MediaWiki\Rest\SimpleHandler;
+use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+use Wikimedia\ParamValidator\ParamValidator;
+
+class GetPersistentPageIdentifiersApi extends SimpleHandler {
+
+	private const PARAM_PAGE_IDS = 'ids';
+
+	public function __construct(
+		private readonly PersistentPageIdentifiersRepo $repo
+	) {
+	}
+
+	public function run(): Response {
+		$params = $this->getValidatedParams();
+
+		return $this->createResponse(
+			$this->repo->getPersistentIds( $params[self::PARAM_PAGE_IDS] )
+		);
+	}
+
+	/**
+	 * @param array<int, string|null> $ids
+	 */
+	private function createResponse( array $ids ): Response {
+		return $this->getResponseFactory()->createJson( [
+			'identifiers' => $ids
+		] );
+	}
+
+	/**
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function getParamSettings(): array {
+		return [
+			self::PARAM_PAGE_IDS => [
+				self::PARAM_SOURCE => 'query',
+				ParamValidator::PARAM_TYPE => 'integer',
+				ParamValidator::PARAM_REQUIRED => true,
+				ParamValidator::PARAM_ISMULTI => true,
+			]
+		];
+	}
+
+	public function needsWriteAccess(): bool {
+		return false;
+	}
+
+}

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -8,6 +8,7 @@ use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\GetPersistentPageIdentifiersApi;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\IdGenerator;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
@@ -53,6 +54,12 @@ class PersistentPageIdentifiersExtension {
 	public function getPageIdsRepo(): PageIdsRepo {
 		return new PageIdsRepo(
 			$this->getDatabase()
+		);
+	}
+
+	public static function newGetPersistentPageIdentifiersApi(): GetPersistentPageIdentifiersApi {
+		return new GetPersistentPageIdentifiersApi(
+			self::getInstance()->getPersistentPageIdentifiersRepo()
 		);
 	}
 

--- a/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php
+++ b/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php
@@ -4,61 +4,102 @@ declare( strict_types = 1 );
 
 namespace ProfessionalWiki\PersistentPageIdentifiers\Tests\Adapters;
 
-use MediaWikiIntegrationTestCase;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Tests\PersistentPageIdentifiersIntegrationTest;
 use Wikimedia\Rdbms\DBError;
 
 /**
  * @covers \ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo
  * @group Database
  */
-class DatabasePersistentPageIdentifiersRepoTest extends MediaWikiIntegrationTestCase {
+class DatabasePersistentPageIdentifiersRepoTest extends PersistentPageIdentifiersIntegrationTest {
+
+	private PersistentPageIdentifiersRepo $repo;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->tablesUsed[] = 'page';
 		$this->tablesUsed[] = 'persistent_page_ids';
-	}
-
-	private function newRepo(): PersistentPageIdentifiersRepo {
-		return new DatabasePersistentPageIdentifiersRepo( $this->db );
+		$this->repo = new DatabasePersistentPageIdentifiersRepo( $this->db );
+		$this->disablePageSaveHook();
 	}
 
 	public function testGetPersistentIdReturnsNullForPageWithoutPersistentId(): void {
-		$repo = $this->newRepo();
-
-		$this->assertNull( $repo->getPersistentId( 404 ) );
+		$this->assertNull( $this->repo->getPersistentId( 404 ) );
 	}
 
 	public function testCanSaveAndRetrievePersistentId(): void {
-		$repo = $this->newRepo();
-		$pageId = 42;
+		$pageId = $this->createPageWithText()->getId();
 		$persistentId = '00000000-0000-0000-0000-000000000042';
 
-		$repo->savePersistentIds( [ $pageId => $persistentId ] );
+		$this->repo->savePersistentIds( [ $pageId => $persistentId ] );
 
-		$this->assertSame( $persistentId, $repo->getPersistentId( $pageId ) );
+		$this->assertSame( $persistentId, $this->repo->getPersistentId( $pageId ) );
 	}
 
 	public function testSetPersistentIdThrowsExceptionOnDuplicatePageId(): void {
-		$repo = $this->newRepo();
-		$pageId = 100;
+		$pageId = $this->createPageWithText()->getId();
 
-		$repo->savePersistentIds( [ $pageId => '00000000-0000-0000-0000-000000000010' ] );
+		$this->repo->savePersistentIds( [ $pageId => '00000000-0000-0000-0000-000000000010' ] );
 
 		$this->expectException( DBError::class );
-		$repo->savePersistentIds( [ $pageId => '00000000-0000-0000-0000-000000000020' ] );
+		$this->repo->savePersistentIds( [ $pageId => '00000000-0000-0000-0000-000000000020' ] );
 	}
 
 	public function testSetPersistentIdThrowsExceptionOnDuplicatePersistentId(): void {
-		$repo = $this->newRepo();
 		$persistentId = '00000000-0000-0000-0000-000000000001';
+		$pageId1 = $this->createPageWithText()->getId();
+		$pageId2 = $this->createPageWithText()->getId();
 
-		$repo->savePersistentIds( [ 100 => $persistentId ] );
+		$this->repo->savePersistentIds( [ $pageId1 => $persistentId ] );
 
 		$this->expectException( DBError::class );
-		$repo->savePersistentIds( [ 200 => $persistentId ] );
+		$this->repo->savePersistentIds( [ $pageId2 => $persistentId ] );
+	}
+
+	public function testGetPersistentIdsReturnsNothingForNonExistentPage(): void {
+		$this->assertSame( [], $this->repo->getPersistentIds( [ 404 ] ) );
+	}
+
+	public function testGetPersistentIdsReturnsNothingForDeletedPage(): void {
+		$page = $this->createPageWithText();
+
+		$this->repo->savePersistentIds( [
+			$page->getId() => '00000000-0000-0000-0000-000000000042'
+		] );
+
+		$this->deletePage( $page );
+
+		$this->assertSame( [], $this->repo->getPersistentIds( [ $page->getId() ] ) );
+	}
+
+	public function testGetPersistentIdsReturnsNullForPageWithoutPersistentId(): void {
+		$pageId = $this->createPageWithText()->getId();
+
+		$this->assertSame( [ $pageId => null ], $this->repo->getPersistentIds( [ $pageId ] ) );
+	}
+
+	public function testCanSaveAndRetrieveMultiplePersistentIds(): void {
+		$pageId1 = $this->createPageWithText()->getId();
+		$pageId2 = $this->createPageWithText()->getId();
+		$pageId3 = $this->createPageWithText()->getId();
+		$persistentId1 = '00000000-0000-0000-0000-000000000042';
+		$persistentId3 = '00000000-0000-0000-0000-000000000043';
+
+		$this->repo->savePersistentIds( [
+			$pageId1 => $persistentId1,
+			$pageId3 => $persistentId3
+		] );
+
+		$this->assertSame(
+			[
+				$pageId1 => $persistentId1,
+				$pageId2 => null,
+				$pageId3 => $persistentId3,
+			],
+			$this->repo->getPersistentIds( [ $pageId1, $pageId2, $pageId3, 404 ] )
+		);
 	}
 
 }


### PR DESCRIPTION
Closes #34 
Replaces #36 

Instead of hacking the core QueryInfo API, just add a simple REST API.

* Takes a list of page ids
* Returns an array of `page_id => peristent_id`.
* Non-existent page ids, or deleted page ids are not returned.
* Existing pages without persistent id get `null`
* Otherwise it gets the actual persistent id
* Does not include any batching or limits for now

Example:
`GET http://localhost:8484/rest.php/persistent-page-identifiers/v0/pages?ids=1|2|3|404`
```json
{
  "1": null,
  "2": "0193318b-43c6-701a-92b1-206b7f951c68"
}
```
(`1` has no id, `2` has an id, `3` was deleted, `404` does not exist)