### PR TITLE
Clear parser cache

### DIFF
--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -6,6 +6,7 @@ namespace ProfessionalWiki\PersistentPageIdentifiers\EntryPoints;
 
 use DatabaseUpdater;
 use IContextSource;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Storage\EditResult;
 use MediaWiki\User\UserIdentity;
@@ -61,6 +62,8 @@ class PersistentPageIdentifiersHooks {
 		PersistentPageIdentifiersExtension::getInstance()->getPersistentPageIdentifiersRepo()->savePersistentIds(
 			[ $wikiPage->getId() => PersistentPageIdentifiersExtension::getInstance()->getIdGenerator()->generate() ]
 		);
+
+		MediaWikiServices::getInstance()->getParserCache()->deleteOptionsKey( $wikiPage );
 	}
 
 }

--- a/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
+++ b/tests/Integration/PersistentPageIdFunctionIntegrationTest.php
@@ -51,8 +51,7 @@ HTML
 	public function testParserFunctionReturnsNothingForPageWithoutPersistentId(): void {
 		$this->disablePageSaveHook();
 
-		$page = $this->createPageWithText();
-		$this->editPage( $page, '{{#ppid:}}' );
+		$page = $this->createPageWithText( '{{#ppid:}}' );
 
 		$this->assertPageContentIs(
 			'',
@@ -63,8 +62,7 @@ HTML
 	public function testParserFunctionReturnsPersistentIdWithCustomFormat(): void {
 		$this->overrideConfigValue( 'PersistentPageIdentifiersFormat', 'foo/$1/bar' );
 
-		$page = $this->createPageWithText();
-		$this->editPage( $page, '{{#ppid:}}' );
+		$page = $this->createPageWithText( '{{#ppid:}}' );
 		$id = $this->repo->getPersistentId( $page->getId() );
 
 		$this->assertPageContentIs(
@@ -80,8 +78,7 @@ HTML
 	public function testParserFunctionEscapesFormattedPersistentId(): void {
 		$this->overrideConfigValue( 'PersistentPageIdentifiersFormat', '<strong>$1<script>alert(42)</script>' );
 
-		$page = $this->createPageWithText();
-		$this->editPage( $page, '{{#ppid:}}' );
+		$page = $this->createPageWithText( '{{#ppid:}}' );
 		$id = $this->repo->getPersistentId( $page->getId() );
 
 		$this->assertPageContentIs(


### PR DESCRIPTION
Fixes #30 

I couldn't find a quick reliable way to clear the cache only when the parser function is actually present. The performance hit is probably neglible.

[Screencast_20241116_190928.webm](https://github.com/user-attachments/assets/8dc1ca5f-3ed0-4045-971a-b7b11364b232)
