### PR TITLE
Add parser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,10 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
         if: matrix.mw == 'master'
 
+      - name: Run parser tests
+        run: php tests/parser/parserTests.php --changetree "null" --file extensions/PersistentPageIdentifiers/tests/parser/*
+        if: matrix.mw == 'REL1_39' || matrix.mw == 'REL1_41' || matrix.mw == 'REL1_42'
+
   PHPStan:
     name: "PHPStan: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: ci test cs phpunit phpcs stan
 
-ci: test cs
+ci: test cs parser
 test: phpunit
 cs: phpcs stan
 
@@ -25,3 +25,6 @@ stan-baseline:
 
 lint-docker:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:20 npm install && npm run lint
+
+parser:
+	php ../../tests/parser/parserTests.php --changetree "null" --file tests/parser/*

--- a/src/Infrastructure/GlobalSequentialIdGenerator.php
+++ b/src/Infrastructure/GlobalSequentialIdGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Infrastructure;
+
+class GlobalSequentialIdGenerator implements IdGenerator {
+
+	private static int $counter = 0;
+
+	public function generate(): string {
+		return 'id-' . ++self::$counter;
+	}
+
+}

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -9,8 +9,10 @@ use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageId
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\GetPersistentPageIdentifiersApi;
+use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PageSaveCompleteHookHandler;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\IdGenerator;
+use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\GlobalSequentialIdGenerator;
 use ProfessionalWiki\PersistentPageIdentifiers\Infrastructure\UuidGenerator;
 use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdFormatter;
 use Wikimedia\Rdbms\IDatabase;
@@ -25,6 +27,10 @@ class PersistentPageIdentifiersExtension {
 	}
 
 	public function getIdGenerator(): IdGenerator {
+		if ( defined( 'MW_PARSER_TEST' ) ) {
+			return new GlobalSequentialIdGenerator();
+		}
+
 		return new UuidGenerator();
 	}
 

--- a/tests/parser/persistentPageIdentifierFunction.txt
+++ b/tests/parser/persistentPageIdentifierFunction.txt
@@ -1,0 +1,45 @@
+!! options
+parsoid-compatible
+version=2
+!! end
+
+# Force the test runner to ensure the extension is loaded
+!! functionhooks
+ppid
+!! endfunctionhooks
+
+!! test
+Returns nothing without a page context
+!! wikitext
+{{#ppid:}}
+!! html
+!! end
+
+!! article
+Test Page
+!! text
+!! endarticle
+
+!! test
+Returns persistent identifier for page
+!! options
+title=[[Test Page]]
+!! wikitext
+{{#ppid:}}
+!! html
+<p>id-8
+</p>
+!! end
+
+!! test
+Returns formatted persistent identifier for page
+!! config
+wgPersistentPageIdentifiersFormat="foo/$1/bar"
+!! options
+title=[[Test Page]]
+!! wikitext
+{{#ppid:}}
+!! html
+<p>foo/id-8/bar
+</p>
+!! end


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/31

The fix in https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/30 makes the ID show up, however since it's a UUID I cannot compare it. 

I added a sequential ID generator, but there are some issues:
* in the parser tests some file pages are created automatically (that's why the number in the test starts at `8`)
* MW 1.43 creates more initial files, so the ID starts at a different number

I couldn't find a nice way to reset the count. `onParserTestGlobals()` runs after test pages have been generated, and there's nothing that I can hook into like PHPUnit test lifecycle methods.