### PR TITLE
Add parser tests using stub repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,9 @@ jobs:
         run: bash <(curl -s https://codecov.io/bash)
         if: matrix.mw == 'master'
 
+      - name: Run parser tests
+        run: php tests/parser/parserTests.php --changetree "null" --file extensions/PersistentPageIdentifiers/tests/parser/*
+
   PHPStan:
     name: "PHPStan: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: ci test cs phpunit phpcs stan
 
 ci: test cs
-test: phpunit
+test: phpunit parser
 cs: phpcs stan
 
 phpunit:
@@ -25,3 +25,6 @@ stan-baseline:
 
 lint-docker:
 	docker run -it --rm -v "$(CURDIR)":/home/node/app -w /home/node/app -u node node:20 npm install && npm run lint
+
+parser:
+	php ../../tests/parser/parserTests.php --changetree "null" --file tests/parser/*

--- a/extension.json
+++ b/extension.json
@@ -34,7 +34,8 @@
 		"InfoAction": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onInfoAction",
 		"LoadExtensionSchemaUpdates": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onLoadExtensionSchemaUpdates",
 		"ParserFirstCallInit": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onParserFirstCallInit",
-		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete"
+		"PageSaveComplete": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onPageSaveComplete",
+		"ParserTestGlobals": "ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks::onParserTestGlobals"
 	},
 
 	"config": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,6 +25,12 @@ parameters:
 			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
 
 		-
+			message: '#^Method ProfessionalWiki\\PersistentPageIdentifiers\\EntryPoints\\PersistentPageIdentifiersHooks\:\:onParserTestGlobals\(\) has parameter \$globals with no value type specified in iterable type array\.$#'
+			identifier: missingType.iterableValue
+			count: 1
+			path: src/EntryPoints/PersistentPageIdentifiersHooks.php
+
+		-
 			message: '#^Method ProfessionalWiki\\PersistentPageIdentifiers\\PersistentPageIdentifiersExtension\:\:getDatabase\(\) should return Wikimedia\\Rdbms\\IDatabase but returns Wikimedia\\Rdbms\\IDatabase\|false\.$#'
 			identifier: return.type
 			count: 1
@@ -32,12 +38,6 @@ parameters:
 
 		-
 			message: '#^Parameter \#1 \$format of class ProfessionalWiki\\PersistentPageIdentifiers\\Presentation\\PersistentPageIdFormatter constructor expects string, mixed given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/PersistentPageIdentifiersExtension.php
-
-		-
-			message: '#^Parameter \#1 \$id of class ProfessionalWiki\\PersistentPageIdentifiers\\Adapters\\StubPersistentPageIdentifiersRepo constructor expects string\|null, mixed given\.$#'
 			identifier: argument.type
 			count: 1
 			path: src/PersistentPageIdentifiersExtension.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -35,3 +35,9 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/PersistentPageIdentifiersExtension.php
+
+		-
+			message: '#^Parameter \#1 \$id of class ProfessionalWiki\\PersistentPageIdentifiers\\Adapters\\StubPersistentPageIdentifiersRepo constructor expects string\|null, mixed given\.$#'
+			identifier: argument.type
+			count: 1
+			path: src/PersistentPageIdentifiersExtension.php

--- a/src/Adapters/StubPersistentPageIdentifiersRepo.php
+++ b/src/Adapters/StubPersistentPageIdentifiersRepo.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace ProfessionalWiki\PersistentPageIdentifiers\Adapters;
+
+use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
+
+class StubPersistentPageIdentifiersRepo implements PersistentPageIdentifiersRepo {
+
+	public function __construct(
+		private readonly ?string $id
+	) {
+	}
+
+	public function savePersistentIds( array $ids ): void {
+		// Do nothing.
+	}
+
+	public function getPersistentId( int $pageId ): ?string {
+		return $this->id;
+	}
+
+	public function getPersistentIds( array $pageIds ): array {
+		return array_combine( $pageIds, array_fill( 0, count( $pageIds ), $this->id ) );
+	}
+
+}

--- a/src/EntryPoints/PersistentPageIdentifiersHooks.php
+++ b/src/EntryPoints/PersistentPageIdentifiersHooks.php
@@ -11,6 +11,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Storage\EditResult;
 use MediaWiki\User\UserIdentity;
 use Parser;
+use ProfessionalWiki\PersistentPageIdentifiers\Adapters\StubPersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\PersistentPageIdentifiersExtension;
 use WikiPage;
 
@@ -64,6 +65,14 @@ class PersistentPageIdentifiersHooks {
 		);
 
 		MediaWikiServices::getInstance()->getParserCache()->deleteOptionsKey( $wikiPage );
+	}
+
+	public static function onParserTestGlobals( array &$globals ): void {
+		PersistentPageIdentifiersExtension::getInstance()->setPersistentPageIdentifiersRepo(
+			new StubPersistentPageIdentifiersRepo(
+				$globals['wgPersistentPageIdentifiersParserTestStubId'] ?? null
+			)
+		);
 	}
 
 }

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -7,7 +7,6 @@ namespace ProfessionalWiki\PersistentPageIdentifiers;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo;
-use ProfessionalWiki\PersistentPageIdentifiers\Adapters\StubPersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\GetPersistentPageIdentifiersApi;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
@@ -17,6 +16,8 @@ use ProfessionalWiki\PersistentPageIdentifiers\Presentation\PersistentPageIdForm
 use Wikimedia\Rdbms\IDatabase;
 
 class PersistentPageIdentifiersExtension {
+
+	private ?PersistentPageIdentifiersRepo $persistentPageIdentifiersRepo = null;
 
 	public static function getInstance(): self {
 		/** @var ?PersistentPageIdentifiersExtension $instance */
@@ -30,19 +31,13 @@ class PersistentPageIdentifiersExtension {
 	}
 
 	public function getPersistentPageIdentifiersRepo(): PersistentPageIdentifiersRepo {
-		if ( defined( 'MW_PARSER_TEST' ) ) {
-			return $this->getParserTestPersistentPageIdentifiersRepo();
+		if ( $this->persistentPageIdentifiersRepo === null ) {
+			$this->persistentPageIdentifiersRepo = new DatabasePersistentPageIdentifiersRepo(
+				$this->getDatabase()
+			);
 		}
 
-		return new DatabasePersistentPageIdentifiersRepo(
-			$this->getDatabase()
-		);
-	}
-
-	private function getParserTestPersistentPageIdentifiersRepo(): PersistentPageIdentifiersRepo {
-		return new StubPersistentPageIdentifiersRepo(
-			$GLOBALS['wgPersistentPageIdentifiersParserTestStubId'] ?? null
-		);
+		return $this->persistentPageIdentifiersRepo;
 	}
 
 	private function getDatabase(): IDatabase {
@@ -72,6 +67,10 @@ class PersistentPageIdentifiersExtension {
 		return new GetPersistentPageIdentifiersApi(
 			self::getInstance()->getPersistentPageIdentifiersRepo()
 		);
+	}
+
+	public function setPersistentPageIdentifiersRepo( PersistentPageIdentifiersRepo $repo ): void {
+		$this->persistentPageIdentifiersRepo = $repo;
 	}
 
 }

--- a/src/PersistentPageIdentifiersExtension.php
+++ b/src/PersistentPageIdentifiersExtension.php
@@ -7,6 +7,7 @@ namespace ProfessionalWiki\PersistentPageIdentifiers;
 use MediaWiki\MediaWikiServices;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\DatabasePersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Adapters\PageIdsRepo;
+use ProfessionalWiki\PersistentPageIdentifiers\Adapters\StubPersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\Application\PersistentPageIdentifiersRepo;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\GetPersistentPageIdentifiersApi;
 use ProfessionalWiki\PersistentPageIdentifiers\EntryPoints\PersistentPageIdFunction;
@@ -29,8 +30,18 @@ class PersistentPageIdentifiersExtension {
 	}
 
 	public function getPersistentPageIdentifiersRepo(): PersistentPageIdentifiersRepo {
+		if ( defined( 'MW_PARSER_TEST' ) ) {
+			return $this->getParserTestPersistentPageIdentifiersRepo();
+		}
+
 		return new DatabasePersistentPageIdentifiersRepo(
 			$this->getDatabase()
+		);
+	}
+
+	private function getParserTestPersistentPageIdentifiersRepo(): PersistentPageIdentifiersRepo {
+		return new StubPersistentPageIdentifiersRepo(
+			$GLOBALS['wgPersistentPageIdentifiersParserTestStubId'] ?? null
 		);
 	}
 

--- a/tests/parser/persistentPageIdentifierFunction.txt
+++ b/tests/parser/persistentPageIdentifierFunction.txt
@@ -1,0 +1,60 @@
+!! options
+parsoid-compatible
+version=2
+!! end
+
+# Force the test runner to ensure the extension is loaded
+!! functionhooks
+ppid
+!! endfunctionhooks
+
+!! test
+Returns nothing without a page context
+!! wikitext
+{{#ppid:}}
+!! html
+!! end
+
+!! article
+Test Page
+!! text
+!! endarticle
+
+!! test
+Returns persistent identifier for page
+!! config
+wgPersistentPageIdentifiersParserTestStubId="test-42"
+wgPersistentPageIdentifiersFormat="$1"
+!! options
+title=[[Test Page]]
+!! wikitext
+{{#ppid:}}
+!! html
+<p>test-42
+</p>
+!! end
+
+!! test
+Returns formatted persistent identifier for page
+!! config
+wgPersistentPageIdentifiersParserTestStubId="test-43"
+wgPersistentPageIdentifiersFormat="foo/$1/bar"
+!! options
+title=[[Test Page]]
+!! wikitext
+{{#ppid:}}
+!! html
+<p>foo/test-43/bar
+</p>
+!! end
+
+!! test
+Returns nothing when page does not have a persistent identifier
+!! config
+wgPersistentPageIdentifiersParserTestStubId=null
+!! options
+title=[[Test Page]]
+!! wikitext
+{{#ppid:}}
+!! html
+!! end


### PR DESCRIPTION
Fixes https://github.com/ProfessionalWiki/PersistentPageIdentifiers/issues/31

Possibly less offensive than https://github.com/ProfessionalWiki/PersistentPageIdentifiers/pull/48

This stubs out the whole repo and replaces it with a hacky config-based test-specific stub ID. So basically it replaces the ID retrieval logic.

I cannot use a similar approach to just stub the IdGenerator when it creates the test pages, because I cannot set `config` when defining `!! article`.