### PR TITLE
Add MariaDB to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         ports:
           - 3306:3306
         env:
+          MYSQL_RANDOM_ROOT_PASSWORD: 1
           MYSQL_DATABASE: mediawiki
           MYSQL_USER: mediawiki
           MYSQL_PASSWORD: mediawiki

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,23 +6,44 @@ on:
 
 jobs:
   test:
-    name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
+    name: "PHPUnit: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}, DB ${{ matrix.db }}"
 
     strategy:
       matrix:
         include:
           - mw: 'REL1_39'
             php: '8.1'
+            db: 'mysql'
+          - mw: 'REL1_39'
+            php: '8.1'
+            db: 'sqlite'
           - mw: 'REL1_41'
             php: '8.2'
+            db: 'sqlite'
           - mw: 'REL1_42'
             php: '8.3'
+            db: 'sqlite'
           - mw: 'REL1_43'
             php: '8.3'
+            db: 'mysql'
+          - mw: 'REL1_43'
+            php: '8.3'
+            db: 'sqlite'
           - mw: 'master'
             php: '8.3'
+            db: 'sqlite'
 
     runs-on: ubuntu-latest
+
+    services:
+      db:
+        image: mariadb
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_DATABASE: mediawiki
+          MYSQL_USER: mediawiki
+          MYSQL_PASSWORD: mediawiki
 
     defaults:
       run:
@@ -44,7 +65,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}_v1
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-${{ matrix.db }}_v1
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -59,7 +80,7 @@ jobs:
       - name: Install MediaWiki
         if: steps.cache-mediawiki.outputs.cache-hit != 'true'
         working-directory: ~
-        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} PersistentPageIdentifiers
+        run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} PersistentPageIdentifiers
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -13,7 +13,7 @@ cd mediawiki
 
 composer install
 if [ "$DB" = "mysql" ]; then
-    php maintenance/install.php --dbtype mysql --dbserver localhost:3306 --dbuser mediawiki --dbpass mediawiki \
+    php maintenance/install.php --dbtype mysql --dbserver 127.0.0.1:3306 --dbuser mediawiki --dbpass mediawiki \
         --dbname mediawiki --pass AdminPassword WikiName AdminUser
 else
     php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) \

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -13,11 +13,11 @@ cd mediawiki
 
 composer install
 if [ "$DB" = "mysql" ]; then
-    php maintenance/install.php --dbtype mysql --dbserver db:3306 --dbuser mediawiki --dbpass mediawiki \
+    php maintenance/install.php --dbtype mysql --dbserver localhost:3306 --dbuser mediawiki --dbpass mediawiki \
         --dbname mediawiki --pass AdminPassword WikiName AdminUser
 else
     php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) \
-        --pass AdminPassword --server http://127.0.0.1 WikiName AdminUser
+        --pass AdminPassword WikiName AdminUser
 fi
 
 cat <<'EOT' >> LocalSettings.php

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -1,7 +1,8 @@
 #! /bin/bash
 
 MW_BRANCH=$1
-EXTENSION_NAME=$2
+DB=$2
+EXTENSION_NAME=$3
 
 wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
 
@@ -11,7 +12,13 @@ mv mediawiki-$MW_BRANCH mediawiki
 cd mediawiki
 
 composer install
-php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) --pass AdminPassword WikiName AdminUser
+if [ "$DB" = "mysql" ]; then
+    php maintenance/install.php --dbtype mysql --dbserver db:3306 --dbuser mediawiki --dbpass mediawiki \
+        --dbname mediawiki --pass AdminPassword WikiName AdminUser
+else
+    php maintenance/install.php --dbtype sqlite --dbuser root --dbname mw --dbpath $(pwd) \
+        --pass AdminPassword --server http://127.0.0.1 WikiName AdminUser
+fi
 
 cat <<'EOT' >> LocalSettings.php
 error_reporting(E_ALL| E_STRICT);


### PR DESCRIPTION
Closes #24 

I used MariaDB just because that's what we use locally.

All jobs run SQLlite, except the 2 LTS (1.39 and 1.43) run MariaDB/MySQL too.