### PR TITLE
Don't skip installation for mysql CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             path: EarlyCopy
 
       - name: Install MediaWiki
-        if: steps.cache-mediawiki.outputs.cache-hit != 'true'
+        if: steps.cache-mediawiki.outputs.cache-hit != 'true' || matrix.db == 'mysql'
         working-directory: ~
         run: bash EarlyCopy/.github/workflows/installMediaWiki.sh ${{ matrix.mw }} ${{ matrix.db }} PersistentPageIdentifiers
 

--- a/.github/workflows/installMediaWiki.sh
+++ b/.github/workflows/installMediaWiki.sh
@@ -4,6 +4,8 @@ MW_BRANCH=$1
 DB=$2
 EXTENSION_NAME=$3
 
+rm -rf mediawiki
+
 wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
 
 tar -zxf $MW_BRANCH.tar.gz


### PR DESCRIPTION
Skipping installation when there is a cache hit works for SQLlite, because the installed SQLite DB ends up in the cache. For MariaDB it has to reinstall the DB every time.