### PR TITLE
Use spaces in extension name in maintenance script

### DIFF
--- a/maintenance/GenerateMissingIdentifiers.php
+++ b/maintenance/GenerateMissingIdentifiers.php
@@ -16,7 +16,7 @@ class GenerateMissingIdentifiers extends Maintenance {
 	public function __construct() {
 		parent::__construct();
 
-		$this->requireExtension( 'PersistentPageIdentifiers' );
+		$this->requireExtension( 'Persistent Page Identifiers' );
 		$this->addDescription( 'Generates persistent identifiers for pages without them' );
 	}
 


### PR DESCRIPTION
Follow-up to https://github.com/ProfessionalWiki/PersistentPageIdentifiers/commit/fcb08f7e093a0af44a644b6dc4ed72c4abfd9f3f