### PR TITLE
Remove MW master from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
           - mw: 'REL1_43'
             php: '8.3'
             db: 'sqlite'
-          - mw: 'master'
-            php: '8.3'
-            db: 'sqlite'
 
     runs-on: ubuntu-latest
 
@@ -98,11 +95,11 @@ jobs:
 
       - name: Run PHPUnit with code coverage
         run: php tests/phpunit/phpunit.php -c extensions/PersistentPageIdentifiers/ --coverage-clover coverage.xml
-        if: matrix.mw == 'master'
+        if: matrix.mw == 'REL1_43'
 
       - name: Upload code coverage
         run: bash <(curl -s https://codecov.io/bash)
-        if: matrix.mw == 'master'
+        if: matrix.mw == 'REL1_43'
 
       - name: Run parser tests
         run: php tests/parser/parserTests.php --changetree "null" --file extensions/PersistentPageIdentifiers/tests/parser/*


### PR DESCRIPTION
Removing it instead of marking experimental:
* we expect MW 1.44+/master to fail due to namespace changes, so it's always going to be red
* marking it experimental is not useful now, because it's going to keep failing until we drop 1.39 support, or else temporarily add removed class aliases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to remove testing for the 'master' MediaWiki branch with PHP 8.3 and SQLite.
  - Adjusted code coverage steps to run only for the 'REL1_43' MediaWiki version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->