### PR TITLE
Fully test getPageIdFromPersistentId

### DIFF
--- a/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php
+++ b/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php
@@ -102,16 +102,25 @@ class DatabasePersistentPageIdentifiersRepoTest extends PersistentPageIdentifier
 		);
 	}
 
-	public function testGetPageIdFromPersistentId(): void {
-		$pageId = $this->createPageWithText()->getId();
-		$persistentId = '00000000-0000-0000-0000-000000000042';
+	public function testGetPageIdReturnsIdMatchingPersistentId(): void {
+		$this->repo->savePersistentIds( [
+			21 => '00000000-0000-0000-0000-000000000021',
+			42 => '00000000-0000-0000-0000-000000000042',
+			84 => '00000000-0000-0000-0000-000000000084',
+		] );
 
-		$this->repo->savePersistentIds( [ $pageId => $persistentId ] );
-		$this->assertSame( $pageId, $this->repo->getPageIdFromPersistentId( $persistentId ) );
+		$this->assertSame(
+			42,
+			$this->repo->getPageIdFromPersistentId( '00000000-0000-0000-0000-000000000042' )
+		);
 	}
 
-	public function testGetPageIdFromNonExistentPersistentId(): void {
-		$this->assertNull( $this->repo->getPageIdFromPersistentId( 'non-existent' ) );
+	public function testGetPageIdReturnsNullForUnknownPersistentId(): void {
+		$this->repo->savePersistentIds( [
+			42 => '00000000-0000-0000-0000-000000000042',
+		] );
+
+		$this->assertNull( $this->repo->getPageIdFromPersistentId( '00000000-0000-0000-0000-000000000404' ) );
 	}
 
 }


### PR DESCRIPTION
Follow up to https://github.com/ProfessionalWiki/PersistentPageIdentifiers/pull/64

@alistair3149 Writing good tests after the fact is more difficult than if you follow the red-green-refactor cycle. You never had the red step for this test, because I could remove the WHERE clause from the query, and it would still pass. To know a test actually does what you want, you need to see it fail first. It's easy to miss testing parts of the production code or to fail to test it altogether due to a mistake in the test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test coverage by saving multiple persistent IDs before querying.
	- Enhanced test clarity with more descriptive test names.
	- Updated assertions to better verify correct behavior for known and unknown persistent IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->