### PR TITLE
Clarify join requirement

### DIFF
--- a/src/Adapters/DatabasePersistentPageIdentifiersRepo.php
+++ b/src/Adapters/DatabasePersistentPageIdentifiersRepo.php
@@ -37,6 +37,7 @@ class DatabasePersistentPageIdentifiersRepo implements PersistentPageIdentifiers
 		$result = $this->database->newSelectQueryBuilder()
 			->select( [ 'p.page_id', 'ppi.persistent_id' ] )
 			->from( 'page', 'p' )
+			// Join is necessary to exclude pages deleted from the `page` table, but not `persistent_page_ids`.
 			->leftJoin( 'persistent_page_ids', 'ppi', 'p.page_id = ppi.page_id' )
 			->where( [ 'p.page_id' => $pageIds ] )
 			->orderBy( 'p.page_id' )


### PR DESCRIPTION
Follow-up to https://github.com/ProfessionalWiki/PersistentPageIdentifiers/pull/64#discussion_r2074362866

The join is necessary to avoid returning persistent IDs for deleted pages (e.g. via REST API).

For reference, the corresponding test:
https://github.com/ProfessionalWiki/PersistentPageIdentifiers/blob/0053bb0cdd3239bf5792ddf040a88accf4b76819/tests/Adapters/DatabasePersistentPageIdentifiersRepoTest.php#L65-L75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a clarifying comment to explain the purpose of a database join, improving code readability for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->