### PR TITLE
Update GenerateMissingIdentifiers.php

### DIFF
--- a/maintenance/GenerateMissingIdentifiers.php
+++ b/maintenance/GenerateMissingIdentifiers.php
@@ -31,7 +31,7 @@ class GenerateMissingIdentifiers extends Maintenance {
 				break;
 			}
 
-			$this->output( "Generating persistent ids for batch of $batchSize pages\n" );
+			$this->output( "Generating persistent IDs for batch of $batchSize pages\n" );
 
 			$idMap = array_combine( $pageIds, $this->generateBulkPersistentIds( $batchSize ) );
 


### PR DESCRIPTION
Fixes typo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated output message to use consistent capitalization for "persistent IDs" in maintenance logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->